### PR TITLE
Enable extra SQLite features and bump version

### DIFF
--- a/container/src/emcc_lua_lib/definition.py
+++ b/container/src/emcc_lua_lib/definition.py
@@ -22,7 +22,17 @@ class Definition():
             self.functions = data.get('functions', [])
             self.entry_file = data.get('entry_file', '')
             self.output_file = data.get('output_file', '')
-            self.extra_compile_arguments = data.get('extra_args', {})
+            self.extra_compile_arguments = {
+                **data.get('extra_args', {})
+            }
+            self.extra_compile_sqlite_arguments = [
+                'SQLITE_ENABLE_MATH_FUNCTIONS',
+                'SQLITE_ENABLE_GEOPOLY',
+                'SQLITE_ENABLE_FTS5',
+                'SQLITE_ENABLE_API_ARMOR',
+            ]
+            self.output_file = data.get('output_file', '')
+
             self.pre_js = data.get('pre_js', '')
 
     def get_entry_file(self):
@@ -35,6 +45,8 @@ class Definition():
         args = []
         for key, val in self.extra_compile_arguments.items():
             args.extend(['-s', '{}={}'.format(key, val)])
+        for key in self.extra_compile_sqlite_arguments:
+            args.extend(['-D{}'.format(key)])
 
         if self.pre_js:
             if not os.path.isfile(self.pre_js):

--- a/container/src/sqlite3.h
+++ b/container/src/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.45.2"
-#define SQLITE_VERSION_NUMBER 3045002
-#define SQLITE_SOURCE_ID      "2024-03-12 11:06:23 d8cd6d49b46a395b13955387d05e9e1a2a47e54fb99f3c9b59835bbefad6af77"
+#define SQLITE_VERSION        "3.45.3"
+#define SQLITE_VERSION_NUMBER 3045003
+#define SQLITE_SOURCE_ID      "2024-04-15 13:34:05 8653b758870e6ef0c98d46b3ace27849054af85da891eb121e9aaa537f1e8355"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -2143,6 +2143,22 @@ struct sqlite3_mem_methods {
 ** configuration setting is never used, then the default maximum is determined
 ** by the [SQLITE_MEMDB_DEFAULT_MAXSIZE] compile-time option.  If that
 ** compile-time option is not set, then the default maximum is 1073741824.
+**
+** [[SQLITE_CONFIG_ROWID_IN_VIEW]]
+** <dt>SQLITE_CONFIG_ROWID_IN_VIEW
+** <dd>The SQLITE_CONFIG_ROWID_IN_VIEW option enables or disables the ability
+** for VIEWs to have a ROWID.  The capability can only be enabled if SQLite is
+** compiled with -DSQLITE_ALLOW_ROWID_IN_VIEW, in which case the capability
+** defaults to on.  This configuration option queries the current setting or
+** changes the setting to off or on.  The argument is a pointer to an integer.
+** If that integer initially holds a value of 1, then the ability for VIEWs to
+** have ROWIDs is activated.  If the integer initially holds zero, then the
+** ability is deactivated.  Any other initial value for the integer leaves the
+** setting unchanged.  After changes, if any, the integer is written with
+** a 1 or 0, if the ability for VIEWs to have ROWIDs is on or off.  If SQLite
+** is compiled without -DSQLITE_ALLOW_ROWID_IN_VIEW (which is the usual and
+** recommended case) then the integer is always filled with zero, regardless
+** if its initial value.
 ** </dl>
 */
 #define SQLITE_CONFIG_SINGLETHREAD         1  /* nil */
@@ -2174,6 +2190,7 @@ struct sqlite3_mem_methods {
 #define SQLITE_CONFIG_SMALL_MALLOC        27  /* boolean */
 #define SQLITE_CONFIG_SORTERREF_SIZE      28  /* int nByte */
 #define SQLITE_CONFIG_MEMDB_MAXSIZE       29  /* sqlite3_int64 */
+#define SQLITE_CONFIG_ROWID_IN_VIEW       30  /* int* */
 
 /*
 ** CAPI3REF: Database Connection Configuration Options


### PR DESCRIPTION
I realized while building on top of this module that by default SQLite is not built with 'advanced' math functions enabled (such as pow or exp)
I enabled this via compiler flag and also added:
- FTS (Full Text Search) support
- Geopoly for limited geojson support
- App armor which adds an additional layer of security (could be good in this context)
Happy to remove those but thought they might be useful in the future

While i was at it I also bumped the SQLite version by updating the source files